### PR TITLE
Fixed #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .stack-work
+tags

--- a/ekg-prometheus-adapter.cabal
+++ b/ekg-prometheus-adapter.cabal
@@ -17,7 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     System.Remote.Monitoring.Prometheus
   build-depends:       base >= 4.7 && < 5
-                     , prometheus < 0.5.0
+                     , prometheus >= 0.4.0 && < 3.0.0
                      , ekg-core   < 0.2.0.0
                      , unordered-containers < 0.3.0.0
                      , containers < 0.6.0.0

--- a/stack-12.19.yaml
+++ b/stack-12.19.yaml
@@ -1,0 +1,31 @@
+resolver: lts-12.19
+
+packages:
+- '.'
+
+extra-deps:
+    - prometheus-2.1.0
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+# 
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: ">=1.1"
+# 
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+# 
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+# 
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor


### PR DESCRIPTION
This commit relaxes the dependency on prometheus so that upstream
library consumers can use the most up-to-date version of the package.

@Mikolaj I think we should be in business now -- as you rightly pointed out nothing was preventing us from using this package with more recent versions of GHC. However, as I was there I took the plunge and relaxed the upper bound on `prometheus` so we can leverage the most up-to-date library around (2.1.0) as we speak.

I have tested this a new `stack-12.19.yaml` file and we were in luck as no modifications of the original library were required!